### PR TITLE
Remove project_id from network name

### DIFF
--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -15,7 +15,7 @@
 */
 
 locals {
-  network_name    = var.network_name == null ? "${var.deployment_name}-net" : var.network_name
+  network_name    = var.network_name == null ? "primary-net" : var.network_name
   subnetwork_name = var.subnetwork_name == null ? "${var.deployment_name}-primary-subnet" : var.subnetwork_name
 
   # define a default subnetwork for cases in which no explicit subnetworks are
@@ -163,7 +163,7 @@ module "nat_ip_addresses" {
   # an external, regional (not global) IP address is suited for a regional NAT
   address_type = "EXTERNAL"
   global       = false
-  names        = [for idx in range(var.ips_per_nat) : "${local.network_name}-nat-ips-${each.value}-${idx}"]
+  names        = [for idx in range(var.ips_per_nat) : "${local.network_name}-nat-ips-${each.value}-${idx}"] #makstest26symbolsintheproj-net-nat-ips-1-1
 }
 
 module "cloud_router" {


### PR DESCRIPTION
Network is used to give hpc-cluster VMs private IPs and provide connetctivity to them through Cloud NAT